### PR TITLE
Support alternative redis clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 **/.DS_Store
 **/Thumbs.db
 spec/*
+coverage/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ var factory = redisSharedObject({
   
 var factory = redisSharedObject(redisClient);	
 
+    // or you can provide a redisClient _and_ a subscriber client
+
+var factory = redisSharedObject({ client: redisClient, subscriber: anotherRedisClient });
+
 factory.createSemaphoreClient('Key', 3 /* initial semaphore count */, function(err, semaphoreClient){}); // returns promise if callback is omitted
 factory.createMutexClient('Key', 10 /* ttl : second */, function(err, mutexClient){});  // returns promise if callback is omitted
 

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -9,8 +9,12 @@ var Promise = require('bluebird'),
 
 exports.factory = function(connect_options, cb){
 	var	mutexTimer = {},
-		SharedObjectFactory = function(connect_options, cb) {		
-			if(connect_options && connect_options.options){
+		SharedObjectFactory = function(connect_options, cb) {
+			if (connect_options && connect_options.client && connect_options.subscriber) {
+				this.client = connect_options.client;
+				this.subscriber = connect_options.subscriber;
+			}
+			else if(connect_options && connect_options.options){
 				this.client = connect_options;
 			}
 			else{
@@ -259,7 +263,12 @@ exports.factory = function(connect_options, cb){
 		that.prefixMutex = 'mutex:';
 		that.sharedObjects = {};
 
-		if(that.client === undefined){		
+		if (that.client && that.subscriber) {
+			if (cb) {
+				cb(null, that.client);
+			}
+		}
+		else if(that.client === undefined){
 			that.client = (new RedisConnector(that.options, function(err, redisClient){
 				if(cb){
 					if(err){

--- a/lib/sharedObject.js
+++ b/lib/sharedObject.js
@@ -378,6 +378,5 @@ SharedObject.prototype.waitingForWithPriority = function(priori, timeout, cb, _c
 };
 
 SharedObject.prototype._publish = function(channel, message){
-	if(this.client.connected)
-		this.client.publish(channel, JSON.stringify(message));	
+	this.client.publish(channel, JSON.stringify(message));
 };


### PR DESCRIPTION
This p/r offers the caller the ability to provide the `subscriber` client in addition to the primary redis client.  This allows the library to be used with [ioredis](https://www.npmjs.com/package/ioredis), and potentially other compatible clients that don't necessarily expose their connection options. This is also useful for cluster clients.

However I'd like to get your opinion about the commit that removes `if(this.client.connected)`. ioredis doesn't expose `connected`, so the `publish` was never getting called.  Is that guard necessary though? Would there ever be a case that publish could get called before the client is connected? And wouldn't we want to consider that an error anyway? 

Thanks!